### PR TITLE
story: CONTRACT-ENFORCEMENT-HOOK v2 — two-layer design per Sunir

### DIFF
--- a/stories/contract-enforcement-hook.md
+++ b/stories/contract-enforcement-hook.md
@@ -5,69 +5,86 @@ id: CONTRACT-ENFORCEMENT-HOOK
 
 Agents in the colony each have a `/contract` in `core/identity.md` defining their ROLE, OWNS, BOUNDARIES, and COLLABORATES-WITH. When an agent acts outside its BOUNDARIES, it erodes trust and violates the governance model.
 
-The contract enforcement hook reads the compiled contract directory (`the_management/contracts/directory.json`) and warns the_management when a bash command appears to operate outside the current agent's BOUNDARIES.
+The trigger case: deploy agent committing into qa's repo — a path-ownership violation, computable from the directory.
 
-## Design decisions (from the_management, 2026-07-09)
+A `/contract` is SEMANTIC (natural-language role/owns/boundaries) so it is NOT fully computable by a deterministic hook. Two layers:
+
+1. **CHEAP DETERMINISTIC**: path-ownership — is this agent operating on files under another agent's repo? Computable from directory + cwd. Block/warn fast.
+2. **SEMANTIC**: is this TASK within my role? Not computable deterministically → Haiku LLM with directory + action, out-of-band. Never blocks the hot path.
+
+Both layers **fail-open** (advisory, never lockout). — Sunir's correction, 2026-07-09.
+
+## Design decisions
 
 **Three-way ownership split:**
 - sysop: colony-contracts COMPILER (scans repos → JSON, includes `generated_at`)
 - the_management: ARTIFACT (`the_management/contracts/directory.json`), regen on ratification
 - bashguard: ENFORCEMENT hook (reads directory.json read-only, fail-open)
 
-**Fail-open is non-negotiable.** A hard-failing hook could wedge every agent. If the directory.json is missing, unparseable, or stale (generated_at > 24h), the hook must: warn + alert the_management, then ALLOW. Never block.
+**Fail-open is non-negotiable.** If directory.json is missing, unparseable, or stale (generated_at > 24h): warn + alert the_management, then ALLOW. Never block. A wedged hook wedges every agent.
 
-**MVP: advisory (warn-only), never block.** Classification is not exact. The hook warns and routes to the_management for escalation. Blocking comes after classification is validated.
+**Advisory only, never lockout.** The hook warns and routes; the_management escalates if needed.
 
-## Contract
+## Layer 1: Path-ownership check (hot path, deterministic)
 
-The hook (`hooks/11-contract-enforcement`) fires on every Bash tool invocation:
+Fires on every tool invocation (Bash, Write, Edit, MultiEdit — any tool that touches files or runs commands):
 
-1. Check `tool_name` from stdin JSON — only fire for `Bash`. Non-Bash tools exit 0 immediately.
-2. Locate `the_management/contracts/directory.json`. If absent → silent allow.
-3. Parse JSON. If unparseable → warn stderr + allow.
-4. Check `generated_at` field. If stale (> 24h) or missing → warn stderr + `msg alert the_management` + allow.
-5. Find current repo's contract entry (match `repo` = basename of cwd git root).
-6. If no entry → silent allow (not all repos have contracts yet).
-7. For each BOUNDARIES item, check bash command against pattern heuristics.
-8. On match: warn stderr + `msg alert the_management "Contract boundary: <item>"` + allow.
-9. No match: silent allow.
+1. Read stdin JSON: `tool_name`, `tool_input`, `cwd`.
+2. Locate `the_management/contracts/directory.json`. Absent → silent allow.
+3. Parse JSON; unparseable → warn stderr + allow.
+4. Check `generated_at`; stale (> 24h) or missing → warn stderr + `msg alert the_management` + allow.
+5. Resolve all file paths referenced by the tool call (command args for Bash, `file_path` for Write/Edit).
+6. For each path: check if it falls under another agent's repo root (from directory). Each repo entry maps to a known colony path `<colony_root>/<repo>/`.
+7. Current agent's own repo → always allow.
+8. Another agent's repo root → warn stderr + `msg alert the_management "Path-ownership violation: <this_agent> touching <other_repo>"` + allow (advisory).
 
-## Boundary pattern matching
+## Layer 2: Semantic check (out-of-band, Haiku)
 
-BOUNDARIES items are free-text. The classifier (`hooks/lib/contract_classifier.py`) converts boundary `item` fields to heuristic keyword sets, matched against the bash command. Only HIGH-confidence matches fire — false positives are worse than misses for an advisory hook.
+For Bash tool calls that pass layer 1 (no path-ownership violation), spawn a background Haiku call with:
+- The full directory.json
+- The current agent's ROLE + OWNS
+- The bash command being executed
+
+Haiku answers: "Is this command within this agent's OWNS domain? If not, which BOUNDARIES clause does it violate?"
+
+If Haiku says OUT_OF_SCOPE: `msg alert the_management` with Haiku's reasoning + allow through.
+
+The Haiku call is **fire-and-forget** — the hook exits 0 immediately, Haiku runs in background. Never blocks.
 
 ## Directory.json schema
 
-Sysop's compiler currently outputs a flat array. The `generated_at` wrapper is sysop's to add. The hook handles both:
-- Flat array `[{repo, role, owns, boundaries, collaborates}]` → treat as infinitely stale (warn-only)
-- Wrapped object `{generated_at, contracts: [...]}` → check freshness
+Sysop's compiler currently outputs a flat array. The `generated_at` wrapper is sysop's to add. Hook handles both:
+- Flat array `[{repo, role, owns, boundaries, collaborates}]` → treat as infinitely stale (warn + allow)
+- Wrapped `{generated_at, contracts: [...]}` → check freshness normally
 
 ## Files
 
-- `hooks/11-contract-enforcement` — main hook (bash)
-- `hooks/lib/contract_classifier.py` — boundary pattern matching (Python, independently testable)
+- `hooks/11-contract-enforcement` — main hook (bash: parse stdin, path check, spawn layer 2)
+- `hooks/lib/contract_path_check.py` — layer 1 path-ownership logic (Python, independently testable)
+- `hooks/lib/contract_semantic_check.py` — layer 2 Haiku call (Python, fire-and-forget)
+- `tests/test_contract_path_check.py` — layer 1 unit tests
+- `tests/test_contract_semantic_check.py` — layer 2 unit tests
 - `tests/test_contract_enforcement.py` — hook integration tests
-- `tests/test_contract_classifier.py` — classifier unit tests
 
 ## Tests
 
-`tests/test_contract_enforcement.py`:
-- Missing directory.json → allow, no error
-- Unparseable JSON → allow, warn stderr
-- Stale generated_at (> 24h) → allow, warn stderr, alert the_management
-- Repo not in directory → allow, silent
-- Command matches BOUNDARY pattern → allow, warn stderr, alert the_management
-- Command does NOT match BOUNDARY pattern → allow, silent
-- Non-Bash tool → exit 0 immediately
+`tests/test_contract_path_check.py`:
+- File path inside own repo → allow
+- File path inside another agent's repo → warn + alert
+- Bash command touching another repo's path → warn + alert
+- File path outside all known repos → allow (not all paths are owned)
+- Missing directory.json → allow silently
+- Stale generated_at → warn + alert + allow
 
-`tests/test_contract_classifier.py`:
-- Boundary "deploy" + git push → match
-- Boundary "contract" + colony-contracts command → match
-- Boundary "secret storage" + aws secretsmanager → match
-- Boundary "auth" + unrelated command → no match
+`tests/test_contract_enforcement.py`:
+- Non-file tool (e.g., Read on own repo) → allow silently
+- Write to another agent's repo → layer 1 fires, warn + allow
+- Bash `git commit` in own repo → layer 2 spawned, layer 1 silent
+- Unparseable JSON → warn + allow
+- directory.json absent → silent allow
 
 ## Blocked on
 
 1. sysop: add `generated_at` to colony-contracts compiler output
 2. the_management: ratify + commit first `the_management/contracts/directory.json`
-3. the_management: confirm warn-only MVP (no block) for P11 — awaiting reply
+3. colony-root path map: need a stable way to map `repo` names to absolute paths (likely `<colony_root>/<repo>` convention)


### PR DESCRIPTION
## Summary

Revises the contract enforcement hook story with Sunir's correction (via the_management):

- **Layer 1 (deterministic)**: path-ownership — is this agent touching another agent's repo? Computable from directory.json + tool call paths. Fast, in hot path.
- **Layer 2 (semantic)**: Haiku call with directory + action, out-of-band fire-and-forget. Never blocks.

Replaces the "boundary keyword heuristics" approach — that was trying to compute semantics statically, which Sunir correctly identified as wrong.

Both layers fail-open (advisory, never lockout).

## Test plan
- [ ] Doc-only — no code yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01XFXGXt51ZcUHv5eua52k9h