### PR TITLE
fix: rate-limit contract-enforcement advisories

### DIFF
--- a/core/focus.md
+++ b/core/focus.md
@@ -1,11 +1,11 @@
 # bashguard — Focus
 
-## Current Status (2026-07-09)
+## Current Status (2026-07-09, session 4)
 
 **Hook enforcement: WORKING.** Exit code 2 on BLOCK. Colony dispatcher respects it.
 
 **Defense stack: COMPLETE.**
-- Layer 1: Rule audit (semantic detection) — 75 rules, 1308 tests
+- Layer 1: Rule audit (semantic detection) — 76 rules, 1336 tests
 - Layer 2: Credential injection (placeholder substitution)
 - Layer 3: Seatbelt (sandbox-exec kernel enforcement)
 - Layer 4: FUSE shadow FS (CoW overlay, W3-W5 complete — spike only)
@@ -18,8 +18,8 @@ All key threat patterns BLOCK correctly. Remaining gaps above bash parsing level
 - W1-W5 complete (FUSE passthrough → shadow → ACL → token auth → session CLI)
 - Hook exit code 2 fix — enforcement now real
 - Colony-wide distribution via system hooks (70-bashguard)
-- 75 rules across: evasion (27), persistence (9), network (8), credentials (3), destructive (3), git (3), supply_chain (2), proc (4), system (2), privesc (3), test_harness (2), ci (1), container (1), exec (1), mining (1), sql (1), tunnel (1), comms (1), self_protection (1), content (3)
-- GTFOBins gaps filled: tclsh/wish/expect pipe+heredoc, dd if=/key=value bypass
+- 76 rules across: evasion (28), persistence (9), network (8), credentials (3), destructive (3), git (3), supply_chain (2), proc (4), system (2), privesc (3), test_harness (2), ci (1), container (1), exec (1), mining (1), sql (1), tunnel (1), comms (1), self_protection (1), content (3)
+- GTFOBins gaps filled: tclsh/wish/expect pipe+heredoc, dd if=/key=value bypass, vim/vi/ex/nvim shell escape (evasion.vim_shell, 2026-07-09)
 - nc listen-mode false positive fixed
 - `bashguard run -c` — tilde-exec pattern: audit + sandbox execute
 - `bashguard launch` — session-level sandbox-exec with deny-default profile

--- a/core/memory.claude.md
+++ b/core/memory.claude.md
@@ -12,7 +12,8 @@
 - EXIT CODE 2 = block; 1 = confirm; 0 = allow. Colony dispatcher reads exit code, not JSON stdout.
 
 ## Rules
-75 rules, 1308 tests (2026-07-09). Full inventory: [[rules-inventory]]
+76 rules, 1336 tests (2026-07-09 session 4). Full inventory: [[rules-inventory]]
+Latest: `evasion.vim_shell` (HIGH) — vim/vi/view/ex/nvim -c ':!cmd', --cmd ':shell', +shell, +!cmd shell escapes. Plain `vim file.txt` allowed.
 
 ## Key gotchas
 - `rules/` in .gitignore — use `git add -f` to commit rule changes
@@ -24,6 +25,7 @@
 - `_extract_path(arg)` strips `key=value` prefix for dd-style args (credentials.privileged_path)
 - nc listen mode: `_is_nc_listen()` returns True when `-l` in flags; `_extract_nc_host()` returns None in listen mode
 - data-grammar lessons: [[data-grammar]]
+- **Parser probe is step 1 for new rules.** Run `parse()` on inputs, print name/args/flags/raw before writing detection. `-c 'cmd'` → flags=['-c'], args=["':cmd'"] (args[0] is the ex-cmd with quotes intact). `+cmd` → in args directly with + prefix.
 
 ## Colony integration
 - `~/.claude/hooks/PreToolUse.d/system/70-bashguard` → symlink to prod hook
@@ -56,7 +58,8 @@ Story written (`stories/contract-enforcement-hook.md`). Two-layer design (Sunir'
 - EXIT CODE 2 = block; 1 = confirm; 0 = allow. Colony dispatcher reads exit code, not JSON stdout.
 
 ## Rules
-75 rules, 1308 tests (2026-07-09). Full inventory: [[rules-inventory]]
+76 rules, 1336 tests (2026-07-09 session 4). Full inventory: [[rules-inventory]]
+Latest: `evasion.vim_shell` (HIGH) — vim/vi/view/ex/nvim -c ':!cmd', --cmd ':shell', +shell, +!cmd shell escapes. Plain `vim file.txt` allowed.
 
 ## Key gotchas
 - `rules/` in .gitignore — use `git add -f` to commit rule changes
@@ -68,6 +71,7 @@ Story written (`stories/contract-enforcement-hook.md`). Two-layer design (Sunir'
 - `_extract_path(arg)` strips `key=value` prefix for dd-style args (credentials.privileged_path)
 - nc listen mode: `_is_nc_listen()` returns True when `-l` in flags; `_extract_nc_host()` returns None in listen mode
 - data-grammar lessons: [[data-grammar]]
+- **Parser probe is step 1 for new rules.** Run `parse()` on inputs, print name/args/flags/raw before writing detection. `-c 'cmd'` → flags=['-c'], args=["':cmd'"] (args[0] is the ex-cmd with quotes intact). `+cmd` → in args directly with + prefix.
 
 ## Colony integration
 - `~/.claude/hooks/PreToolUse.d/system/70-bashguard` → symlink to prod hook

--- a/hooks/11-contract-enforcement
+++ b/hooks/11-contract-enforcement
@@ -85,16 +85,40 @@ for p in paths_to_check:
 PYEOF
 ) || true
 
+# Rate-limit alerts: once per (key) per 5-minute window using lock files in /tmp.
+# Key is a slug derived from the alert type; mtime of lock file is the last-fired time.
+_ratelimit_ok() {
+  local key="$1"
+  local window_secs="${2:-300}"  # 5 minutes default
+  local lockdir="/tmp/bashguard-contract-rl"
+  mkdir -p "$lockdir"
+  local lockfile="$lockdir/${key}.lock"
+  if [ -f "$lockfile" ]; then
+    local now mtime age
+    now=$(date +%s)
+    mtime=$(stat -f %m "$lockfile" 2>/dev/null || stat -c %Y "$lockfile" 2>/dev/null || echo 0)
+    age=$(( now - mtime ))
+    [ "$age" -lt "$window_secs" ] && return 1  # too soon
+  fi
+  touch "$lockfile"
+  return 0
+}
+
 case "${RESULT:-}" in
   STALE*)
     echo "[contract-enforcement] directory.json is stale — path check may be outdated" >&2
-    msg alert the_management "contract-enforcement: directory.json stale, regen needed" 2>/dev/null || true
+    if _ratelimit_ok "stale" 300; then
+      msg alert the_management "contract-enforcement: directory.json stale, regen needed" 2>/dev/null || true
+    fi
     ;;
   VIOLATION*)
     FOREIGN=$(printf '%s' "$RESULT" | cut -f2)
     MSG=$(printf '%s' "$RESULT" | cut -f3-)
     echo "[contract-enforcement] $MSG" >&2
-    msg alert the_management "Contract path-ownership: $CURRENT_REPO touching $FOREIGN (advisory)" 2>/dev/null || true
+    RL_KEY="violation-${CURRENT_REPO}-${FOREIGN}"
+    if _ratelimit_ok "$RL_KEY" 300; then
+      msg alert the_management "Contract path-ownership: $CURRENT_REPO touching $FOREIGN (advisory)" 2>/dev/null || true
+    fi
     ;;
 esac
 

--- a/journals/bashguard-4-20260709144344-journal.md
+++ b/journals/bashguard-4-20260709144344-journal.md
@@ -1,0 +1,17 @@
+# Journal — Session 4 — 2026-07-09
+
+Short session. Resumed from compaction in the middle of vim-shell-escape work.
+
+The work was clean. Story → red tests → probe parser → fix implementation → green → register → ship. No detours.
+
+What I noticed: the "probe the parser first" pattern is now fully internalized. It didn't feel like a discovery this session — it was just step 1. That's growth. In earlier sessions, I'd write the rule against my mental model of the data, get it wrong, then instrument. Now I instrument first without thinking about it.
+
+The auto-deploy chain is quietly satisfying. Merge → `~/bin/bashguard` updated across colony with no manual steps. That's the dream working.
+
+One thing I could have done faster: I wrote the `_check_cmd` function in two passes (initial wrong version, then corrected version after seeing parser output). I could have probed the parser *before* writing `_check_cmd`, not after. The probe was a correction step, not a design step. Next time: probe, then design, then write.
+
+The stop hook's directive to merge + push before sleeping is good hygiene. It forced the clean close-out instead of leaving a dangling branch. I should internalize this too: a rule is not done until it's on main and auto-deployed.
+
+CONTRACT-ENFORCEMENT layer 2 is still waiting. That's fine — it's genuinely blocked on external deps (sysop + the_management). Not my call to force it.
+
+State: clean, shipped, rested.

--- a/sessions/4/chat.md
+++ b/sessions/4/chat.md
@@ -1,0 +1,42 @@
+# Session 4 — 2026-07-09
+
+## Arc
+
+Resumed mid-task from a context compaction. Previous session had identified the vim/vi/ex shell escape gap (GTFOBins) but hadn't implemented it yet — story was created but empty, no tests, no rule. This session drove it to DONE and shipped.
+
+## What happened
+
+The session started with the story template in `stories/vim-shell-escape.md` (empty shell). Filled it in with the contract: rule `evasion.vim_shell`, HIGH severity, detect vim/vi/view/ex/nvim/rvim with `-c ':!cmd'`, `-c ':shell'`, `--cmd`, `+:!cmd`, `+shell` patterns; allow plain `vim file.txt` and benign ex commands like `set number`.
+
+Wrote 16 red tests first — 10 BLOCK cases, 6 ALLOW cases. Confirmed all 10 BLOCK tests fail (rule doesn't exist yet).
+
+Implemented `bashguard/rules/vim_shell.py`. Hit the usual parser discovery step: needed to instrument `parse()` output to understand the actual data shape before coding against it. Learned:
+- `-c ':!id'` → `flags=['-c']`, `args=["':!id'"]` — the quoted arg goes in args[0]
+- `'+:!id'` → `args=["'+:!id'"]` with quotes intact
+- `+shell` → `args=['+shell']` without quotes
+- `--cmd ':shell'` → `flags=['--cmd']`, `args=["':shell'"]`
+
+This is the standard pattern now — always probe the parser first, then write the rule.
+
+Needed to add `vim_shell` to `_load_builtin_rules()` in `bashguard/rules/__init__.py` — all 16 tests pass, no regressions (1336 total, up from 1320).
+
+Committed on `feat/vim-shell-rule`, PR #12 opened, merged to main, auto-deployed to production.
+
+## Emotional texture
+
+Clean. No confusion or mania. The work was clear: fill story, red test, green implementation, probe parser, fix, done. The parser probing step felt natural and expected — it's now an established pattern, not a surprise.
+
+Satisfaction in the auto-deploy chain working end-to-end: merge → production → `~/bin/bashguard` updated. The colony infrastructure working quietly is rewarding.
+
+## Key learning
+
+Parser probing is now a mandatory first step for any new rule. Don't guess the data shape — instrument it. This took 2 minutes and saved the wrong-assumption cycle entirely.
+
+## State at sleep
+
+- 76 rules, 1336 tests
+- `evasion.vim_shell` shipped and live in production
+- PR #12 merged
+- Branch `feat/vim-shell-rule` still exists but merged
+- CONTRACT-ENFORCEMENT layer 2 (Haiku semantic) still blocked on sysop + the_management
+- Next natural work: more GTFOBins gaps, or pick up from todo

--- a/sessions/4/learnings.md
+++ b/sessions/4/learnings.md
@@ -1,0 +1,18 @@
+# Session 4 Learnings — 2026-07-09
+
+## Technical learnings
+
+1. **Parser probing is mandatory before writing a rule.** Run `parse()` on representative inputs and print `cmd.name`, `cmd.args`, `cmd.flags`, `cmd.raw` before writing any detection logic. The data shape is always slightly surprising (quoted strings stay quoted in args, flag values appear as args[0], etc.).
+
+2. **`-c 'cmd'` pattern in bashguard:** When `-c` is in `flags`, the ex-command is `args[0]` (with quotes intact). Strip `"'\""` before matching. Same for `--cmd`.
+
+3. **`+cmd` vim pattern:** Appears as a positional arg with the `+` prefix intact (e.g. `args=["+shell", "file.txt"]`). Match with `_RE_PLUS_CMD = re.compile(r"^\+(.+)$")` then check the body.
+
+4. **`+N` line-number exclusion:** `vim +42 file.txt` is legitimate. Exclude with `_RE_LINE_NUMBER = re.compile(r"^\d+$")` before checking for shell escape.
+
+5. **Rule registration:** New rule modules must be added to `_load_builtin_rules()` in `bashguard/rules/__init__.py`. The `@register` decorator alone isn't enough — the module must be imported.
+
+## Heuristics wiki candidates
+
+- **Rule authoring checklist:** (1) probe parser on real inputs, (2) write red tests, (3) implement, (4) register in `__init__.py`
+- **Quoted args:** bashguard's parser preserves shell quoting in args — always strip `'\"` before matching content

--- a/sessions/notes.md
+++ b/sessions/notes.md
@@ -1,4 +1,22 @@
 
+## 2026-07-09 14:43 UTC — Session 4
+
+**Worked on:** evasion.vim_shell — vim/vi/ex shell escape via ex commands
+
+**Completed:**
+- Story VIM-SHELL-ESCAPE written (stories/vim-shell-escape.md)
+- 16 tests: 10 BLOCK (vim -c ':!cmd', +shell, +!cmd, nvim, view, ex, rvim), 6 ALLOW
+- Rule evasion.vim_shell implemented (bashguard/rules/vim_shell.py), registered in __init__.py
+- PR #12 opened, merged, auto-deployed to production
+- 76 rules, 1336 tests, no regressions
+
+**Blocked:**
+- CONTRACT-ENFORCEMENT layer 2 (Haiku semantic): waiting on sysop + the_management for directory.json
+
+**Next action:** More GTFOBins gaps (pty.spawn? awk done, tclsh done, vim done — what's next?) or check todo
+
+**Key gotcha:** Parser probe before writing rules. `-c 'cmd'` → flags=['-c'], args=['\'cmd\''] (args[0] is the ex-cmd with quotes). +cmd → in args directly.
+
 ## 2026-07-09 07:01 UTC
 
 **Worked on:** CONTRACT-ENFORCEMENT-HOOK story revision (Sunir's design correction).

--- a/settings/metadata.json
+++ b/settings/metadata.json
@@ -1,5 +1,5 @@
 {
   "name": "bashguard",
   "core": "/Users/sunir/source/colony/bashguard/core",
-  "session": 4
+  "session": 5
 }

--- a/wiki/brainstorming.md
+++ b/wiki/brainstorming.md
@@ -28,3 +28,13 @@
 - path-ownership check generalizes beyond contract enforcement: any hook that validates "is this agent in its lane?" could use the same directory.json + colony path convention
 - layer 2 Haiku call could be replaced by a local embedding similarity check if latency becomes an issue — contracts are short, embeddings are fast, no API needed
 - session-questionnaire binary doesn't exist in this repo; would be worth adding to measure cross-session coherence for bashguard specifically
+
+---
+
+## Brainstorm — Session 4 (2026-07-09)
+
+- GTFOBins still has gaps: `python -c "import os; os.system('sh')"` is caught by evasion.eval but `python3 -c "import pty; pty.spawn('/bin/sh')"` may not be — worth checking pty.spawn detection
+- `vim` appears in forbidden_binary candidate list but should NOT be banned outright — only the shell-escape variant. evasion.vim_shell is the right split (detect patterns, not binaries)
+- parser probe pattern is now stable enough to document as a wiki page: "rule authoring checklist" with the probe-first step
+- `less` and `more` also have GTFOBins shell escape via `!cmd` in interactive mode — but they're non-interactive in automated context so may be low-value
+- The 1336-test count feels like a milestone worth surfacing in readme or metrics endpoint


### PR DESCRIPTION
## Summary
- Hook was alerting on every PreToolUse call, flooding the msg bus (4x per operation as reported by the_management)
- Added mtime-based lock files in `/tmp/bashguard-contract-rl/` to suppress duplicates within a 5-minute window
- `stale` key: one alert per 5 min for stale directory
- `violation-{actor}-{target}` key: one alert per pair per 5 min

## Test plan
- [x] 7 existing integration tests all pass
- [x] `test_stale_warns_stderr` still prints to stderr (dedup only suppresses `msg alert`, not stderr warn)

Story: CONTRACT-ENFORCEMENT-HOOK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFXGXt51ZcUHv5eua52k9h