### PR TITLE
fix: contract-enforcement read/write split — skip Bash and Read

### DIFF
--- a/hooks/11-contract-enforcement
+++ b/hooks/11-contract-enforcement
@@ -12,8 +12,11 @@ INPUT=$(cat)
 TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c \
   "import json,sys; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || true)
 
+# Only check write-class tools. Read is almost always legitimate (cross-cutting roles
+# read other repos constantly). Bash cwd-based check is too blunt for cross-cutting
+# roles (deploy legitimately runs in any repo). Skip both.
 case "${TOOL_NAME:-}" in
-  Bash|Write|Edit|MultiEdit|Read) ;;
+  Write|Edit|MultiEdit) ;;
   *) exit 0 ;;
 esac
 
@@ -63,16 +66,13 @@ directory_json = Path(os.environ["DIRECTORY_JSON"])
 directory = load_directory(directory_json)
 
 paths_to_check = []
-if tool_name == "Bash":
-    paths_to_check.append(Path(cwd))
-else:
-    fp = tool_input.get("file_path") or tool_input.get("path")
-    if fp:
-        paths_to_check.append(Path(fp))
-    for edit in tool_input.get("edits", []):
-        fp2 = edit.get("file_path")
-        if fp2:
-            paths_to_check.append(Path(fp2))
+fp = tool_input.get("file_path") or tool_input.get("path")
+if fp:
+    paths_to_check.append(Path(fp))
+for edit in tool_input.get("edits", []):
+    fp2 = edit.get("file_path")
+    if fp2:
+        paths_to_check.append(Path(fp2))
 
 if directory and directory.is_stale():
     print("STALE")

--- a/tests/test_contract_enforcement.py
+++ b/tests/test_contract_enforcement.py
@@ -46,14 +46,16 @@ class TestFailOpen:
     # Story: CONTRACT-ENFORCEMENT-HOOK
 
     def test_missing_directory_silent_allow(self, tmp_path: Path) -> None:
-        code, out, err = _run("Bash", {"command": "ls"}, str(tmp_path))
+        code, out, err = _run("Write", {"file_path": str(tmp_path / "f.py")}, str(tmp_path))
         assert code == 0
         assert err == ""
 
-    def test_non_bash_tool_silent_allow(self, tmp_path: Path) -> None:
-        code, out, err = _run("TaskCreate", {}, str(tmp_path))
-        assert code == 0
-        assert err == ""
+    def test_non_write_tool_silent_allow(self, tmp_path: Path) -> None:
+        """Bash, Read, TaskCreate — not write-class tools — are always silent."""
+        for tool in ("Bash", "Read", "TaskCreate"):
+            code, out, err = _run(tool, {}, str(tmp_path))
+            assert code == 0, f"{tool} should exit 0"
+            assert err == "", f"{tool} should produce no stderr"
 
     def test_always_exits_0(self, tmp_path: Path) -> None:
         """Even with a violation, exit 0 — advisory only."""
@@ -93,8 +95,9 @@ class TestStaleDirectory:
         dir_path.mkdir(parents=True)
         (dir_path / "directory.json").write_text(json.dumps(DIRECTORY_STALE))
 
-        code, out, err = _run("Bash", {"command": "ls"}, str(bashguard_repo),
-                              colony_root=str(colony_root))
+        # Use Write (a write-class tool) so the hook doesn't exit early
+        code, out, err = _run("Write", {"file_path": str(bashguard_repo / "x.py")},
+                              str(bashguard_repo), colony_root=str(colony_root))
         assert code == 0
         assert "stale" in err.lower()
 


### PR DESCRIPTION
## Summary
- Root cause: the hook was checking Bash (cwd-based) and Read tool calls, which fire constantly for cross-cutting roles (deploy, sysop, the_management) legitimately operating across repos
- Fix: only Write/Edit/MultiEdit to another repo's source trigger VIOLATION advisory
- Bash and Read are skipped at the tool filter — cross-cutting reads are legitimate
- Clears the "deploy touching qa" false positive class

## Context
the_management confirmed the "deploy touching qa" catches were stale/benign — deploy legitimately cross-cuts all repos. The real violation class is **writes to another repo's source**, not reads or bash commands.

## Test plan
- [x] 7 integration tests pass
- [x] `test_non_write_tool_silent_allow` now covers Bash, Read, TaskCreate
- [x] Write to other repo still warns

Story: CONTRACT-ENFORCEMENT-HOOK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFXGXt51ZcUHv5eua52k9h